### PR TITLE
Fix account name not being exported properly.

### DIFF
--- a/Forms/Primary.cs
+++ b/Forms/Primary.cs
@@ -1061,7 +1061,7 @@ namespace DSLauncherV2
                     XmlAttribute sigAttribute = xmlDocument.CreateAttribute("signature");
                     sigAttribute.Value = row.Cells[5].Value.ToString();
 
-                    element2.InnerText = row.Cells[1].Value.ToString();
+                    element2.InnerText = row.Cells[0].Value.ToString();
                     element2.Attributes.Append(descriptionAttribute);
                     element2.Attributes.Append(categoryAttribute);
                     element2.Attributes.Append(favAttribute);


### PR DESCRIPTION
Simple fix; the name value is defined by the innerText value of the XML entry for every account, but the innerText was being wrongly set as the second item in the row's array of cells, which would be the account description and not the account name.