### PR TITLE
Fix issue with name export.

### DIFF
--- a/Forms/Primary.cs
+++ b/Forms/Primary.cs
@@ -1061,7 +1061,7 @@ namespace DSLauncherV2
                     XmlAttribute sigAttribute = xmlDocument.CreateAttribute("signature");
                     sigAttribute.Value = row.Cells[5].Value.ToString();
 
-                    element2.InnerText = row.Cells[1].Value.ToString();
+                    element2.InnerText = row.Cells[0].Value.ToString();
                     element2.Attributes.Append(descriptionAttribute);
                     element2.Attributes.Append(categoryAttribute);
                     element2.Attributes.Append(favAttribute);


### PR DESCRIPTION
InnerText of XML contains the name value of an account, but the export process was incorrectly assigning that value as the second entry in the row of cells, which is the description and not account name.