### PR TITLE
Some Fix in Version Check & Save, and SelfPatch Downloading

### DIFF
--- a/Self Patch/Patch.cs
+++ b/Self Patch/Patch.cs
@@ -13,6 +13,7 @@ using System.Net;
 using System.Net.Cache;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Xml;
 
@@ -65,19 +66,19 @@ namespace DSSelfPatch
 
         private void CheckConnectivity()
 		{
-            if (this.settings.RemotePatchLocation.Contains("discoverygc.com"))
-            {
-                this.settings.RemotePatchLocation = "http://patch.discoverygc.net/";
-            }
+			if (this.settings.RemotePatchLocation.Contains("discoverygc.com"))
+			{
+				this.settings.RemotePatchLocation = "http://patch.discoverygc.net/";
+			}
 
-            try
+			try
             { 
                 WebClient webClient = new WebClient()
 				{
 					CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore),
 				};
-                ServicePointManager.SecurityProtocol = (SecurityProtocolType)0xc00;
-                webClient.DownloadFile(this.settings.RemotePatchLocation, this.settings.PatchListTempFile);
+				ServicePointManager.SecurityProtocol = (SecurityProtocolType)0xc00;
+				webClient.DownloadFile(this.settings.RemotePatchLocation, this.settings.PatchListTempFile);
 				webClient.Dispose();
 			}
 
@@ -128,8 +129,8 @@ namespace DSSelfPatch
 				{
 					CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore)
 				};
-			    ServicePointManager.SecurityProtocol = (SecurityProtocolType)0xc00;
-                webClient.DownloadFile(this.settings.RemotePatchLocation, this.settings.PatchListTempFile);
+				ServicePointManager.SecurityProtocol = (SecurityProtocolType)0xc00;
+				webClient.DownloadFile(this.settings.RemotePatchLocation, this.settings.PatchListTempFile);
 				webClient.Dispose();
 				this.label1.Invoke(new MethodInvoker(() => {
 					this.label1.Text = "OK, Kitty is reachable.";
@@ -261,16 +262,12 @@ namespace DSSelfPatch
 				XmlElement xmlElement1 = xmlElement;
 				if (xmlElement != null)
 				{
-				    if (Version.TryParse(xmlElement.InnerText, out Version version))
-				    {
-				        this.settings.LocalLauncherVersion = version;
-				    }
-
-				    else
-				    {
-                        int[] i = xmlElement.InnerText.ToCharArray().Select(Convert.ToInt32).ToArray();
-				        this.settings.LocalLauncherVersion = new Version(i[0], i[1], i[2]);
-				    }
+					String versionS = xmlElement.InnerText;
+					if (Regex.IsMatch(versionS, @"^[+-]?\d*$"))
+					{
+						versionS = versionS[0] + "." + versionS[1] + "." + versionS[2];
+					}
+					Version.TryParse(versionS, out this.settings.LocalLauncherVersion);
 				}
 				XmlElement xmlElement2 = xmlNodes.SelectSingleNode("InstallPath") as XmlElement;
 				xmlElement1 = xmlElement2;
@@ -341,7 +338,12 @@ namespace DSSelfPatch
 				XmlElement xmlElement1 = xmlElement;
 				if (xmlElement != null)
 				{
-					this.settings.RemoteLauncherVersion = Version.Parse(xmlElement1.InnerText);
+					String versionS = xmlElement.InnerText;
+					if (Regex.IsMatch(versionS, @"^[+-]?\d*$"))
+					{
+						versionS = versionS[0] + "." + versionS[1] + "." + versionS[2];
+					}
+					Version.TryParse(versionS, out this.settings.RemoteLauncherVersion);
 				}
 				streamReader.Close();
 				streamReader.Dispose();

--- a/Self Patch/Patch.cs
+++ b/Self Patch/Patch.cs
@@ -66,19 +66,19 @@ namespace DSSelfPatch
 
         private void CheckConnectivity()
 		{
-			if (this.settings.RemotePatchLocation.Contains("discoverygc.com"))
-			{
-				this.settings.RemotePatchLocation = "http://patch.discoverygc.net/";
-			}
+            if (this.settings.RemotePatchLocation.Contains("discoverygc.com"))
+            {
+                this.settings.RemotePatchLocation = "http://patch.discoverygc.net/";
+            }
 
-			try
+            try
             { 
                 WebClient webClient = new WebClient()
 				{
 					CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore),
 				};
-				ServicePointManager.SecurityProtocol = (SecurityProtocolType)0xc00;
-				webClient.DownloadFile(this.settings.RemotePatchLocation, this.settings.PatchListTempFile);
+                ServicePointManager.SecurityProtocol = (SecurityProtocolType)0xc00;
+                webClient.DownloadFile(this.settings.RemotePatchLocation, this.settings.PatchListTempFile);
 				webClient.Dispose();
 			}
 
@@ -129,8 +129,8 @@ namespace DSSelfPatch
 				{
 					CachePolicy = new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore)
 				};
-				ServicePointManager.SecurityProtocol = (SecurityProtocolType)0xc00;
-				webClient.DownloadFile(this.settings.RemotePatchLocation, this.settings.PatchListTempFile);
+			    ServicePointManager.SecurityProtocol = (SecurityProtocolType)0xc00;
+                webClient.DownloadFile(this.settings.RemotePatchLocation, this.settings.PatchListTempFile);
 				webClient.Dispose();
 				this.label1.Invoke(new MethodInvoker(() => {
 					this.label1.Text = "OK, Kitty is reachable.";

--- a/Self Patch/Patch.cs
+++ b/Self Patch/Patch.cs
@@ -363,7 +363,7 @@ namespace DSSelfPatch
 		{
 		    foreach (KeyValuePair<int, UserSettings.PatchListDataStruct> patchListDatum in this.settings.PatchListData)
 			{
-				string str = string.Concat(this.settings.InstallPath, "\\", patchListDatum.Value.PatchURL);
+				string str = string.Concat(this.settings.InstallPath, "\\", patchListDatum.Value.PatchName);
 				if (!this.CompareMD5(str, patchListDatum.Value.PatchMD5Hash))
 				{
 					try

--- a/Self Patch/Patch.cs
+++ b/Self Patch/Patch.cs
@@ -51,7 +51,7 @@ namespace DSSelfPatch
 
 		private void backgroundWorker1_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
 		{
-			if (this.settings.RemoteLauncherVersion.CompareTo(this.settings.LocalLauncherVersion) < 0)
+			if (this.settings.RemoteLauncherVersion.CompareTo(this.settings.LocalLauncherVersion) > 0)
 			{
 				this.startDownloadBackgroundWorker.RunWorkerAsync();
 				return;

--- a/Settings/LauncherSettings.cs
+++ b/Settings/LauncherSettings.cs
@@ -49,12 +49,12 @@ namespace DSLauncherV2
 
                     try
                     {
-                        if(Regex.IsMatch(this.UserSettings.Config.LocalLauncherVersionS, @"^[+-]?\d*$"))
+                        if(Regex.IsMatch(this.UserSettings.Config.LocalLauncherStringVersion, @"^[+-]?\d*$"))
                         {
-                            char[] i = this.UserSettings.Config.LocalLauncherVersionS.ToCharArray();
-                            this.UserSettings.Config.LocalLauncherVersionS = i[0]+"."+ i[1]+"."+ i[2];
+                            char[] i = this.UserSettings.Config.LocalLauncherStringVersion.ToCharArray();
+                            this.UserSettings.Config.LocalLauncherStringVersion = i[0]+"."+ i[1]+"."+ i[2];
                         }
-                        this.UserSettings.Config.LocalLauncherVersion = new Version(this.UserSettings.Config.LocalLauncherVersionS);
+                        this.UserSettings.Config.LocalLauncherVersion = new Version(this.UserSettings.Config.LocalLauncherStringVersion);
                     }
                     catch
                     {

--- a/Settings/LauncherSettings.cs
+++ b/Settings/LauncherSettings.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
@@ -48,8 +49,11 @@ namespace DSLauncherV2
 
                     try
                     {
-                        int[] i = this.UserSettings.Config.LocalLauncherVersion.ToString().ToCharArray().Select(Convert.ToInt32).ToArray();
-                        this.UserSettings.Config.LocalLauncherVersion = new Version(i[0], i[1], i[2]);
+                        if(Regex.IsMatch(this.UserSettings.Config.LocalLauncherVersionS, @"^[+-]?\d*$"))
+                        {
+                            this.UserSettings.Config.LocalLauncherVersionS = this.UserSettings.Config.LocalLauncherVersionS[0]+"."+ this.UserSettings.Config.LocalLauncherVersionS[1]+"."+ this.UserSettings.Config.LocalLauncherVersionS[2];
+                        }
+                        this.UserSettings.Config.LocalLauncherVersion = new Version(this.UserSettings.Config.LocalLauncherVersionS);
                     }
                     catch
                     {
@@ -177,7 +181,12 @@ namespace DSLauncherV2
                 xmlDocument.Load(streamReader);
                 if (!(xmlDocument.SelectSingleNode("/PatcherData/Settings/launcherversion") is XmlElement xml1))
                     return;
-                Version.TryParse(xml1.InnerText, out Version version);
+                String versionS = xml1.InnerText;
+                if (Regex.IsMatch(versionS, @"^[+-]?\d*$"))
+                {
+                    versionS = versionS[0] + "." + versionS[1] + "." + versionS[2];
+                }
+                Version.TryParse(versionS, out Version version);
                 if (version == null)
                     return;
                 this.UserSettings.RemoteLauncherVersion = version;

--- a/Settings/LauncherSettings.cs
+++ b/Settings/LauncherSettings.cs
@@ -51,7 +51,8 @@ namespace DSLauncherV2
                     {
                         if(Regex.IsMatch(this.UserSettings.Config.LocalLauncherVersionS, @"^[+-]?\d*$"))
                         {
-                            this.UserSettings.Config.LocalLauncherVersionS = this.UserSettings.Config.LocalLauncherVersionS[0]+"."+ this.UserSettings.Config.LocalLauncherVersionS[1]+"."+ this.UserSettings.Config.LocalLauncherVersionS[2];
+                            char[] i = this.UserSettings.Config.LocalLauncherVersionS.ToCharArray();
+                            this.UserSettings.Config.LocalLauncherVersionS = i[0]+"."+ i[1]+"."+ i[2];
                         }
                         this.UserSettings.Config.LocalLauncherVersion = new Version(this.UserSettings.Config.LocalLauncherVersionS);
                     }

--- a/Settings/UserSettings.cs
+++ b/Settings/UserSettings.cs
@@ -117,7 +117,7 @@ namespace DSLauncherV2
         public string ExtraArgs { get; set; }
 
         [XmlElement("LauncherVersion")]
-        public String LocalLauncherVersionS { get; set; }
+        public string LocalLauncherStringVersion { get; set; }
 
         [XmlIgnore]
         public Version LocalLauncherVersion { get; set; }

--- a/Settings/UserSettings.cs
+++ b/Settings/UserSettings.cs
@@ -117,6 +117,9 @@ namespace DSLauncherV2
         public string ExtraArgs { get; set; }
 
         [XmlElement("LauncherVersion")]
+        public String LocalLauncherVersionS { get; set; }
+
+        [XmlIgnore]
         public Version LocalLauncherVersion { get; set; }
 
         [XmlElement("Style")]


### PR DESCRIPTION
(Sorry for my bad English)

1.Using a Regex to check the format of version is 'XXX' or 'X.X.X'. 
If it is the former one, add dots between digital to transform it into the latter one. 
Then transform it into Version Type.

2.Add a String named LocalLauncherVersionS in User Setting, which take place of LocalLauncherVersion in XML file.
Version type can't be saved into a XML file,but String can.
Once the config file is loaded, it will be transformed using the way below and assigned into LocalLauncherVersion.

3.Fix a small problem in version comparation in self patch.

4.Fix a error in path combination in self path, which accidently add URL of file instead of filename after install path.